### PR TITLE
Display statistic map even if excursion set is empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.pyc
+build/*
+*egg*/*
+dist/*

--- a/nidmviewer/convert.py
+++ b/nidmviewer/convert.py
@@ -6,6 +6,7 @@ Functions to convert/parse output from nidm sparql queries
 """
 
 from nidmviewer.utils import read_file_lines
+from numpy import isnan, float64
 import pandas 
 
 def parse_coordinates(coordinates):
@@ -24,7 +25,10 @@ def parse_coordinates(coordinates):
     count=0
     coordinate_df = pandas.DataFrame(columns=["x","y","z"])
     for coordinate in coordinates:
-        coordinate_df.loc[count] = [x.strip() for x in coordinate.strip("]").strip("[").split(",")]
+        if not isinstance(coordinate, float64) or not isnan(coordinate):
+            coordinate_df.loc[count] = [x.strip() for x in coordinate.strip("]").strip("[").split(",")]
+        else:
+            coordinate_df.loc[count] = [None, None, None]
         count+=1
     return coordinate_df
 

--- a/nidmviewer/sparql.py
+++ b/nidmviewer/sparql.py
@@ -73,6 +73,7 @@ def get_coordinates_and_maps(ttl_file):
             ?statmap a statistic_map: ;
                 statistic_type: ?statmap_type ;
                 prov:atLocation ?statmap_location .
+            OPTIONAL {
             ?peak prov:wasDerivedFrom/prov:wasDerivedFrom/prov:wasGeneratedBy/prov:used ?statmap ;
                 prov:atLocation ?coord ;
                 equivalent_zstatistic: ?z_score ;
@@ -80,6 +81,7 @@ def get_coordinates_and_maps(ttl_file):
                 prov:atLocation ?coordinate_id .
             ?coordinate_id rdfs:label ?coord_name ;
                 coordinate: ?coordinate .
+                }
             }
             """
     return do_query(ttl_file,query)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 rdflib
 rdfextras
 rdflib-jsonld
+pandas>=0.18.1

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,10 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
+# Get requirements from requirements.txt file
+reqs = [line.strip() for line in open('requirements.txt').readlines()]
+requirements = list(filter(None, reqs))
+
 setup(
     # Application name:
     name="nidmviewer",
@@ -34,7 +38,7 @@ setup(
     long_description=long_description,
     keywords='nidm nidm-results brain imaging neuroimaging',
 
-    install_requires = ['numpy','rdflib', 'rdfextras', 'rdflib-jsonld'],
+    install_requires = requirements,
 
     entry_points = {
         'console_scripts': [


### PR DESCRIPTION
This PR fixes #9 by enabling display of a statistic map in the absence of suprathreshold voxels.

Tested on my machine the following command:

```
nidmviewer PATH_TO_EXAMPLE/fsl_ds005_group/nidm.ttl
```

returns:
![image](https://cloud.githubusercontent.com/assets/5374264/15602306/6a0077da-23ec-11e6-968c-b42b85c81a83.png)
