### PR TITLE
Empty peaks and/or excursion set

### DIFF
--- a/nidmviewer/convert.py
+++ b/nidmviewer/convert.py
@@ -25,7 +25,12 @@ def parse_coordinates(coordinates):
     count=0
     coordinate_df = pandas.DataFrame(columns=["x","y","z"])
     for coordinate in coordinates:
-        coordinate_df.loc[count] = [x.strip() for x in coordinate.strip("]").strip("[").split(",")]
+        if isinstance(coordinate, str):
+            print coordinate
+            coordinate_df.loc[count] = [x.strip() for x in coordinate.strip("]").strip("[").split(",")]
+        # This happens when there are no coordinates
+        elif isinstance(coordinate, float64) and isnan(coordinate):
+            coordinate_df.loc[count] = [None, None, None]
         count+=1
     return coordinate_df
 

--- a/nidmviewer/convert.py
+++ b/nidmviewer/convert.py
@@ -26,7 +26,6 @@ def parse_coordinates(coordinates):
     coordinate_df = pandas.DataFrame(columns=["x","y","z"])
     for coordinate in coordinates:
         if isinstance(coordinate, str):
-            print coordinate
             coordinate_df.loc[count] = [x.strip() for x in coordinate.strip("]").strip("[").split(",")]
         # This happens when there are no coordinates
         elif isinstance(coordinate, float64) and isnan(coordinate):

--- a/nidmviewer/viewer.py
+++ b/nidmviewer/viewer.py
@@ -7,6 +7,8 @@ from nidmviewer.templates import get_template, add_string, save_template, remove
 from nidmviewer.sparql import get_coordinates_and_maps
 from nidmviewer.convert import parse_coordinates
 from nidmviewer.browser import view
+import nibabel as nib
+import numpy as np
 import os
 import sys
 
@@ -92,6 +94,16 @@ def generate(ttl_files,base_image=None,retrieve=False,view_in_browser=False,colu
 
     if view_in_browser==True:
         peaks,copy_list = generate_temp(peaks,"excsetmap_location")
+        # Check if the nifti is empty
+        for exc_set_file in copy_list.keys():
+            img = nib.load(exc_set_file)
+            data = img.get_data()
+            data = np.nan_to_num(data)
+            if np.count_nonzero(data) == 0:
+                # Empty excursion set is removed from the display list
+                del copy_list[exc_set_file]
+                peaks[peaks.keys()[0]] = {}
+
         if base_image == None:
             base_image = get_standard_brain(load=False)
             dummy_peak = {base_image: [{"excsetmap_location":base_image}]}


### PR DESCRIPTION
Hi @vsoch! 
This is an extension of your current PR #12, that implements:
-  1addc4f: deal with empty list of peaks: we need some sort of test on the coordinates to deal with the case when no peaks/clusters are listed (e.g. in http://neurovault.org/collections/1404/fsl_ds005_sub-01.nidm)
-  dfcd645: check if the excursion set is empty and if so remove it form the list of images to be displayed.

Do you know if there is a way to change the message displayed in the table when the peaks structure is empty to say "No significant voxels." instead of "No matchingf record found."?
