### PR TITLE
Look for redirects when loading image URLs (HTTP to HTTPS redirects)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ rdflib-jsonld
 pandas
 nibabel
 pyparsing==1.5.7
+requests

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     description="command line or server tool to view or compare nidm results.",
     keywords='nidm nidm-results brain imaging neuroimaging',
 
-    install_requires = ['numpy','rdflib','rdfextras','rdflib-jsonld','pandas', 'nibabel, 'pyparsing==1.5.7'],
+    install_requires = ['numpy','rdflib','rdfextras','rdflib-jsonld','pandas', 'nibabel', 'pyparsing==1.5.7','requests'],
 
     entry_points = {
         'console_scripts': [


### PR DESCRIPTION
Hi @vsoch,

Here is a fix following our discussion at: https://github.com/NeuroVault/NeuroVault/issues/607. 

The proposed solution is to look for any redirect when absolute URLs are provided for the images. So, for any image hosted on NeuroVault, if a `http://neurovault.org/SOMETHING` URL is found it will be replaced by `https://neurovault.org/SOMETHING`.

With this fix, we can keep existing turtle documents already available on NeuroVault (that contain URLs starting with `http://neurovault`), e.g. [this one](https://neurovault.org/collections/1425/pain_01.nidm/nidm.ttl), as they are.

How does this sound?

Camille